### PR TITLE
✨ use pkg_resources for fetching version

### DIFF
--- a/ai_commit_msg/main.py
+++ b/ai_commit_msg/main.py
@@ -3,7 +3,7 @@ import argparse
 import sys
 import os
 from typing import Sequence
-import configparser
+import pkg_resources
 
 from ai_commit_msg.cli.config_handler import config_handler, handle_config_setup
 from ai_commit_msg.cli.gen_ai_commit_message_handler import gen_ai_commit_message_handler
@@ -16,9 +16,7 @@ def called_from_git_hook():
     return os.environ.get('PRE_COMMIT') == '1'
 
 def get_version():
-    config = configparser.ConfigParser()
-    config.read('setup.cfg')
-    return config['metadata']['version']
+    return pkg_resources.get_distribution("git-ai-commit").version
 
 def main(argv: Sequence[str] = sys.argv[1:]) -> int:
     if called_from_git_hook():


### PR DESCRIPTION
…pkg_resources.

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Currently, we fetch the version by searching for `setup.cfg` file and reading the version from that file metadata. However in production build that file does not exist. This causes a crash when users run `git-ai-commit --version`bt

In this PR we leverage the pkg_resource to obtain the version name. this library presumably does not retrieve the version from the `setup.cfg` file. This seems to resolve the crash and properly returns the version number

## Test Plan

<!-- Provide details of a testing plan that include details on how to reproduce and success parameters. Provide screenshots/videos of log, output, etc. -->

build and install to get latest changes

```bash
pip install . && pre-commit install && pre-commit autoupdate
```

upload package to test Pypi registry
```
twine upload --repository-url https://test.pypi.org/legacy/ ./dist/git_ai_commit-1.0.5.tar.gz
```

uninstall the package locally
```
pip uninstall git-ai-commit      
```

re-install the pack from the registry
```
pip install -i https://test.pypi.org/simple/ git-ai-commit
```

check the version command does not crash and properly returns the correct version
```
gac --version
```


