### PR TITLE
Add `git-ai-command summary` command 

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,20 @@ git-ai-commit config --openai-key=... --model=gpt-4o-mini
 
 ---
 
+🔎 `git-ai-commit summarize`
+
+Get a quick summary of your local changes
+
+```bash
+git-ai-commit summarize
+```
+
+- `-u` `--unstaged`
+
+  Summarize your local *unstaged* changes.
+
+---
+
 📌 `git-ai-commit  help`, `-h`
 
 Displays a list of available command and options to help you setup our tool.

--- a/ai_commit_msg/cli/gen_ai_commit_message_handler.py
+++ b/ai_commit_msg/cli/gen_ai_commit_message_handler.py
@@ -7,7 +7,8 @@ def gen_ai_commit_message_handler():
       print("🚨 No files are staged for commit. Run `git add` to stage some of your changes")
       return
 
-    ai_gen_commit_msg = generate_commit_message()
+    staged_diff = GitService.get_staged_diff()
+    ai_gen_commit_msg = generate_commit_message(staged_diff.stdout)
 
     command_string = f"""
 git commit -m "{ai_gen_commit_msg}"

--- a/ai_commit_msg/cli/summary_handler.py
+++ b/ai_commit_msg/cli/summary_handler.py
@@ -1,0 +1,29 @@
+from ai_commit_msg.core.gen_commit_msg import generate_commit_message
+from ai_commit_msg.services.git_service import GitService
+from ai_commit_msg.utils.logger import Logger
+from ai_commit_msg.utils.utils import execute_cli_command
+
+def print_summary(summary):
+  Logger().log(f"""Here is a summary of your changes:
+
+  {summary}
+""")
+
+def summary_handler(args):
+  if args.unstaged:
+    Logger().log("Fetching your unstaged changes...\n")
+    unstaged_changes_diff = execute_cli_command(['git', 'diff'])
+    ai_commit_msg = generate_commit_message(unstaged_changes_diff)
+    print_summary(ai_commit_msg)
+    return
+
+  Logger().log("Fetching your staged changes...\n")
+
+  if(len(GitService.get_staged_files()) == 0):
+    Logger().log("🚨 No files are staged for commit. Run `git add` to stage some of your changes")
+    return
+
+  staged_changes_diff = execute_cli_command(['git', 'diff', '--staged'])
+  ai_commit_msg = generate_commit_message(staged_changes_diff)
+
+  print_summary(ai_commit_msg)

--- a/ai_commit_msg/cli/summary_handler.py
+++ b/ai_commit_msg/cli/summary_handler.py
@@ -7,13 +7,15 @@ def print_summary(summary):
   Logger().log(f"""Here is a summary of your changes:
 
   {summary}
+
+to use this summary run: `git commit -m "{summary}"`
 """)
 
 def summary_handler(args):
   if args.unstaged:
     Logger().log("Fetching your unstaged changes...\n")
     unstaged_changes_diff = execute_cli_command(['git', 'diff'])
-    ai_commit_msg = generate_commit_message(unstaged_changes_diff)
+    ai_commit_msg = generate_commit_message(unstaged_changes_diff.stdout)
     print_summary(ai_commit_msg)
     return
 
@@ -24,6 +26,6 @@ def summary_handler(args):
     return
 
   staged_changes_diff = execute_cli_command(['git', 'diff', '--staged'])
-  ai_commit_msg = generate_commit_message(staged_changes_diff)
+  ai_commit_msg = generate_commit_message(staged_changes_diff.stdout)
 
   print_summary(ai_commit_msg)

--- a/ai_commit_msg/core/gen_commit_msg.py
+++ b/ai_commit_msg/core/gen_commit_msg.py
@@ -9,6 +9,10 @@ from ai_commit_msg.utils.logger import Logger
 from ai_commit_msg.utils.models import ANTHROPIC_MODEL_LIST, OPEN_AI_MODEL_LIST
 
 def generate_commit_message(diff: str = None) -> str:
+
+  if diff is None:
+    raise ValueError("Diff is required to generate a commit message")
+
   COMMIT_MSG_SYSTEM_MESSAGE = '''
 You will be provided with a set of code changes in diff format.
 Your task is to read each file and explain every major change in a concise way.

--- a/ai_commit_msg/core/gen_commit_msg.py
+++ b/ai_commit_msg/core/gen_commit_msg.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from ai_commit_msg.services.anthropic_service import AnthropicService
 from ai_commit_msg.services.config_service import ConfigService
 from ai_commit_msg.services.git_service import GitService
@@ -6,9 +8,7 @@ from ai_commit_msg.services.openai_service import OpenAiService
 from ai_commit_msg.utils.logger import Logger
 from ai_commit_msg.utils.models import ANTHROPIC_MODEL_LIST, OPEN_AI_MODEL_LIST
 
-def generate_commit_message():
-  staged_diff = GitService.get_staged_diff()
-
+def generate_commit_message(diff: str = None) -> str:
   COMMIT_MSG_SYSTEM_MESSAGE = '''
 You will be provided with a set of code changes in diff format.
 Your task is to read each file and explain every major change in a concise way.
@@ -26,7 +26,7 @@ Only respond with a short sentence no longer than 50 characters that I can use f
 
   prompt = [
           {"role": "system", "content": COMMIT_MSG_SYSTEM_MESSAGE},
-          {"role": "user", "content": staged_diff.stdout},
+          {"role": "user", "content": diff},
       ]
 
   # TODO - create a factory with a shared interface for calling the LLM models, this will make it easier to add new models

--- a/ai_commit_msg/main.py
+++ b/ai_commit_msg/main.py
@@ -5,6 +5,7 @@ import os
 from typing import Sequence
 import pkg_resources
 
+from ai_commit_msg.cli.summary_handler import summary_handler
 from ai_commit_msg.cli.config_handler import config_handler, handle_config_setup
 from ai_commit_msg.cli.gen_ai_commit_message_handler import gen_ai_commit_message_handler
 from ai_commit_msg.cli.hook_handler import hook_handler
@@ -43,6 +44,7 @@ def main(argv: Sequence[str] = sys.argv[1:]) -> int:
     config_parser.add_argument('-a', '--anthropic-key', dest='anthropic_key', help='🔑 Set your Anthropic API key for AI-powered commit messages')
     config_parser.add_argument('-s', '--setup', action='store_true', help='🔧 Setup the tool')
     config_parser.add_argument('-p', '--prefix', help='🏷️ Set a prefix for the commit message')
+
     # Help command
     subparsers.add_parser('help', help='Display this help message')
 
@@ -51,6 +53,12 @@ def main(argv: Sequence[str] = sys.argv[1:]) -> int:
     hook_parser.add_argument('-s','--setup', action='store_true', help='Setup the prepare-commit-msg hook')
     hook_parser.add_argument('-r','--remove', action='store_true', help='Remove the prepare-commit-msg hook')
     hook_parser.add_argument('-x','--run', action='store_true', help='Run the prepare-commit-msg hook')
+
+    summarize_cmd_parser = subparsers.add_parser('summarize', help='🚀 Generate an AI commit message')
+    summary_cmd_parser = subparsers.add_parser('summary', help='🚀 Generate an AI commit message')
+    summarize_cmd_parser.add_argument('-u','--unstaged', action='store_true', help='Setup the prepare-commit-msg hook')
+    summary_cmd_parser.add_argument('-u','--unstaged', action='store_true', help='Setup the prepare-commit-msg hook')
+
     args = parser.parse_args(argv)
 
     if args.command == 'config':
@@ -59,6 +67,8 @@ def main(argv: Sequence[str] = sys.argv[1:]) -> int:
         parser.print_help()
     elif args.command == 'hook':
         hook_handler(args)
+    elif args.command == 'summarize' or args.command == 'summary':
+        summary_handler(args)
 
     ## Only in main script, we return zero instead of None when the return value is unused
     return 0

--- a/ai_commit_msg/prepare_commit_msg_hook.py
+++ b/ai_commit_msg/prepare_commit_msg_hook.py
@@ -11,8 +11,8 @@ def prepare_commit_msg_hook():
   if(filtered_content != ""):
     Logger().log("Commit message already exists, skipping AI commit message generation")
     return
-
-  commit_message = generate_commit_message()
+  staged_diff = GitService.get_staged_diff()
+  commit_message = generate_commit_message(staged_diff.stdout)
 
   GitService.update_commit_message(commit_message)
 


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

The `git-ai-command summary` command will simply provide a commit message or concise summary of local staged/unstaged changes. 

This diff adds two command I couldn't pick between which word to use. would love to get reviewers opinions
- `git-ai-command summary`
- `git-ai-command summarize`

## Test Plan

<!-- Provide details of a testing plan that include details on how to reproduce and success parameters. Provide screenshots/videos of log, output, etc. -->

build and install local changes

```
pip install . && pre-commit install && pre-commit autoupdate
```

Run the new command to summarize all your unstaged changes
```
> git-ai-commit summary --unstaged                            
Fetching your unstaged changes...

Here is a summary of your changes:

  ✨fix summary_handler to use stdout from diff command

to use this summary run: `git commit -m "✨fix summary_handler to use stdout from diff command"
```

Run the new command to summarize all your staged changes

```
> git-ai-commit summarize                                     
Fetching your staged changes...

Here is a summary of your changes:

  ✨fix stdout usage in generate_commit_message calls

to use this summary run: `git commit -m "✨fix stdout usage in generate_commit_message calls"`
```

