### PR TITLE
✨[nux] use input lib for API key setup, fix open ai key getting cut off

### DIFF
--- a/ai_commit_msg/services/onboarding_service.py
+++ b/ai_commit_msg/services/onboarding_service.py
@@ -89,9 +89,7 @@ def onboarding_flow():
 
     if provider_choice in ['openai', 'anthropic']:
         print_formatted_text(HTML(f"\n<b>Let's set up your {provider_choice.capitalize()} API key.</b>"))
-        api_key = inquirer.prompt([
-            inquirer.Password('key', message=f"Enter your {provider_choice.capitalize()} API key")
-        ])['key']
+        api_key = input(f"[?] Enter your {provider_choice.capitalize()} API key: ")
         if api_key:
             getattr(config_service, f"set_{provider_choice}_api_key")(api_key)
             console.print(f"{provider_choice.capitalize()} API key set successfully!", style="bold green")


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Patches the bugs where the open ai key step in the NUX repeats when you copy/paste a value

![image](https://github.com/user-attachments/assets/9a40ccc1-ec50-4af0-96ac-ced7e0947d4f)

as well as bug where the open ai key was getting cut off 

## Test Plan

<!-- Provide details of a testing plan that include details on how to reproduce and success parameters. Provide screenshots/videos of log, output, etc. -->

build and install to obtain the latest changes

```bash
pip install . && pre-commit install && pre-commit autoupdate
```

enter the NUX
```
gac config --setup
```

select the open ai provider, choose an arbitrary model, 

copy/paste an API key, observe bug where the input text repeats

click enter to continue. observe API key in the local JSON store contain an API key that shorter than the user provided string.
