### PR TITLE
added default model selections for each provider

### DIFF
--- a/ai_commit_msg/services/onboarding_service.py
+++ b/ai_commit_msg/services/onboarding_service.py
@@ -72,6 +72,12 @@ def onboarding_flow():
                       choices=['OpenAI', 'Anthropic', 'Ollama'])
     ])['provider'].lower()
 
+    default_models = {
+        'openai': 'gpt-4o-mini',
+        'anthropic': 'claude-3-sonnet-20240229',
+        'ollama': 'ollama/llama3'
+    }
+
     model_choices = {
         'openai': OPEN_AI_MODEL_LIST,
         'anthropic': ANTHROPIC_MODEL_LIST,
@@ -81,7 +87,8 @@ def onboarding_flow():
     model_choice = inquirer.prompt([
         inquirer.List('model',
                       message="Select Model",
-                      choices=model_choices[provider_choice])
+                      choices=model_choices[provider_choice],
+                      default=default_models[provider_choice])
     ])['model']
 
     config_service = ConfigService()


### PR DESCRIPTION
## Description

This PR introduces a default Model for each LLM Model:

Defaults Models are
1. OpenAI: gpt-4o-mini 
2. Anthropic: claude-3-sonnet-20240229
3. Ollama: ollama/llama3


## Test Plan

```
 pip install . && pre-commit install && pre-commit autoupdate
```

```
gac config --setup
```

## Expected output:

### Default OpenAI Model (Demo)

https://github.com/user-attachments/assets/626ed36b-9880-4bf5-a4f7-a4bf97946914


### Default Anthropic Model (Demo)

https://github.com/user-attachments/assets/61a6e70d-3874-42ac-a7f0-c9d28bf20970


### Default Ollama Model (Demo)


https://github.com/user-attachments/assets/62ee0c34-908a-42db-9302-bd2afa2b025c






