### PR TITLE
fix bugs for v1.0.7

### DIFF
--- a/ai_commit_msg/cli/hook_handler.py
+++ b/ai_commit_msg/cli/hook_handler.py
@@ -31,8 +31,6 @@ fi
     return PREPARE_COMMIT_MSG_BASH_SCRIPT
 
 def handle_setup_hook(hook_directory_path: str):
-    Logger().log("[Setup] Git prepare-commit-msg hook")
-
     existing_hook_content = ""
     if os.path.exists(hook_directory_path):
       with open(hook_directory_path, 'r') as file:
@@ -43,7 +41,7 @@ def handle_setup_hook(hook_directory_path: str):
         return
 
     if existing_hook_content:
-      override_content = input("prepare-commit-msg hook already exists. Would you like to overwrite it? (y/n): ")
+      override_content = input(f"prepare-commit-msg hook already exists in {hook_directory_path}\n\nWould you like to overwrite it? (y/n): ")
 
       if override_content.lower() == 'n':
         return
@@ -84,14 +82,22 @@ def setup_husky_git_hook():
 
     return
 
+
+def setup_git_hook():
+    Logger().log("[Setup] Git prepare-commit-msg hook")
+
+    # check if husky is installed, if it is, setup husky hook
+    if HuskyService.repo_has_husky_framework():
+        setup_husky_git_hook()
+
+    file_path = GitService.get_git_prepare_commit_msg_hook_path()
+    handle_setup_hook(file_path)
+
+    return
+
 def hook_handler(args):
     if args.setup:
-        # check if husky is installed, if it is, setup husky hook
-        if HuskyService.repo_has_husky_framework():
-            setup_husky_git_hook()
-
-        file_path = GitService.get_git_prepare_commit_msg_hook_path()
-        handle_setup_hook(file_path)
+        setup_git_hook()
         return
 
     if args.setup_husky:

--- a/ai_commit_msg/cli/hook_handler.py
+++ b/ai_commit_msg/cli/hook_handler.py
@@ -7,7 +7,6 @@ from ai_commit_msg.services.husky_service import HuskyService
 from ai_commit_msg.utils.logger import Logger
 from ai_commit_msg.utils.utils import get_version
 
-
 def get_bash_script():
     version = get_version()
     id = uuid.uuid4()

--- a/ai_commit_msg/services/git_service.py
+++ b/ai_commit_msg/services/git_service.py
@@ -108,7 +108,7 @@ class GitService:
 
   @staticmethod
   def get_git_config_value(key: GitConfigKeysEnum):
-    return execute_cli_command(['git', 'config', '--get', key]).stdout.strip()
+    return execute_cli_command(['git', 'config', '--local', key]).stdout.strip()
 
   @staticmethod
   def get_git_prepare_commit_msg_hook_path():

--- a/ai_commit_msg/services/husky_service.py
+++ b/ai_commit_msg/services/husky_service.py
@@ -1,6 +1,7 @@
 import os
 
 from ai_commit_msg.services.git_service import GitConfigKeysEnum, GitService
+from ai_commit_msg.utils.logger import Logger
 
 HUSKY_GENERATED_GIT_HOOK_PATH = ".husky/_"
 
@@ -8,11 +9,14 @@ class HuskyService:
 
   @staticmethod
   def repo_has_husky_framework():
-    git_hook_path_config_value = GitService.get_git_config_value(GitConfigKeysEnum.hookPath.value)
-    hook_path_is_husky = git_hook_path_config_value == HUSKY_GENERATED_GIT_HOOK_PATH
-    husky_directory_exists = os.path.exists(GitService.get_repo_root_directory() + "/" + HUSKY_GENERATED_GIT_HOOK_PATH)
+    try:
+      git_hook_path_config_value = GitService.get_git_config_value(GitConfigKeysEnum.hookPath.value)
+      hook_path_is_husky = git_hook_path_config_value == HUSKY_GENERATED_GIT_HOOK_PATH
+      husky_directory_exists = os.path.exists(GitService.get_repo_root_directory() + "/" + HUSKY_GENERATED_GIT_HOOK_PATH)
 
-    return hook_path_is_husky and husky_directory_exists
+      return hook_path_is_husky and husky_directory_exists
+    except Exception:
+      return False
 
   @staticmethod
   def get_husky_prepare_commit_msg_hook_path():

--- a/ai_commit_msg/services/onboarding_service.py
+++ b/ai_commit_msg/services/onboarding_service.py
@@ -9,7 +9,7 @@ from prompt_toolkit.formatted_text import HTML
 from prompt_toolkit import print_formatted_text
 from ai_commit_msg.services.git_service import GitService
 from ai_commit_msg.services.config_service import ConfigService
-from ai_commit_msg.cli.hook_handler import handle_setup_hook
+from ai_commit_msg.cli.hook_handler import setup_git_hook
 from ai_commit_msg.utils.models import OPEN_AI_MODEL_LIST, ANTHROPIC_MODEL_LIST, OLLAMA_MODEL_LIST
 from rich.panel import Panel
 from rich.style import Style
@@ -63,7 +63,7 @@ def onboarding_flow():
         console.print("Please ensure Git is installed and you're in a Git repository.", style="bold red")
         sys.exit(1)
 
-    handle_setup_hook()
+    setup_git_hook()
 
     print_formatted_text(HTML("\n<b>Choose your preferred AI provider:</b>"))
     provider_choice = inquirer.prompt([


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Patch a crash that occurs when you execute husky setup in a repo that doesn't have it

```
> gac hook --setup  
Traceback (most recent call last):
  File "/Users/ming1in/.pyenv/versions/3.9.6/lib/python3.9/site-packages/ai_commit_msg/utils/utils.py", line 7, in execute_cli_command
    result = subprocess.run(
  File "/Users/ming1in/.pyenv/versions/3.9.6/lib/python3.9/subprocess.py", line 528, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['git', 'config', '--get', 'core.hooksPath']' returned non-zero exit status 1.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/ming1in/.pyenv/versions/3.9.6/bin/gac", line 8, in <module>
    sys.exit(main())
  File "/Users/ming1in/.pyenv/versions/3.9.6/lib/python3.9/site-packages/ai_commit_msg/main.py", line 68, in main
    hook_handler(args)
  File "/Users/ming1in/.pyenv/versions/3.9.6/lib/python3.9/site-packages/ai_commit_msg/cli/hook_handler.py", line 90, in hook_handler
    if HuskyService.repo_has_husky_framework():
  File "/Users/ming1in/.pyenv/versions/3.9.6/lib/python3.9/site-packages/ai_commit_msg/services/husky_service.py", line 11, in repo_has_husky_framework
    git_hook_path_config_value = GitService.get_git_config_value(GitConfigKeysEnum.hookPath.value)
  File "/Users/ming1in/.pyenv/versions/3.9.6/lib/python3.9/site-packages/ai_commit_msg/services/git_service.py", line 111, in get_git_config_value
    return execute_cli_command(['git', 'config', '--get', key]).stdout.strip()
  File "/Users/ming1in/.pyenv/versions/3.9.6/lib/python3.9/site-packages/ai_commit_msg/utils/utils.py", line 24, in execute_cli_command
    raise Exception(error_msg)
Exception: 🚨 Total failure to call: git config --get core.hooksPath
```


## Test Plan

Build and install the latest change

```bash
> pip install . && pre-commit install && pre-commit autoupdate
```

Run this command in a repo without husky installed

```bash
> gac hook --setup  
```
