### PR TITLE
🐞 fix(setup): add setuptools dependency to resolve pkg_resources import error

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ install_requires =
     pyfiglet
     prompt_toolkit
     inquirer
+    setuptools
 python_requires = >=3.6
 
 [options.extras_require]


### PR DESCRIPTION
## Description

- Added `setuptools` to `install_requires` in setup.cfg
- Fixes `ModuleNotFoundError: No module named 'pkg_resources'` on Python 3.12+
- This error occurred because setuptools was not listed as a dependency

Note: This commit provides a temporary fix by ensuring setuptools is installed. However, pkg_resources is deprecated and will be removed after 2025-11-30. Future versions should replace pkg_resources with importlib.metadata.

## Test Plan

---
fixes: #82