### PR TITLE
♻️ refactor(utils): remove unused pkg_resources import

### DIFF
--- a/ai_commit_msg/services/pip_service.py
+++ b/ai_commit_msg/services/pip_service.py
@@ -1,5 +1,5 @@
 import requests
-import pkg_resources
+from importlib.metadata import version
 
 from ai_commit_msg.utils.logger import Logger
 
@@ -20,7 +20,7 @@ class PipService:
 
     @staticmethod
     def get_version():
-        return pkg_resources.get_distribution(PACKAGE_NAME).version
+        return version(PACKAGE_NAME)
 
     @staticmethod
     def version_is_older(current_version: str, latest_version: str) -> bool:

--- a/ai_commit_msg/utils/utils.py
+++ b/ai_commit_msg/utils/utils.py
@@ -1,5 +1,4 @@
 import subprocess
-import pkg_resources
 
 
 # TODO - get repo root directory without using git command


### PR DESCRIPTION
## Summary

- Removes unused `import pkg_resources` from `ai_commit_msg/utils/utils.py`
- Replaces `pkg_resources.get_distribution()` with `importlib.metadata.version()` in `ai_commit_msg/services/pip_service.py`
- Fixes Python 3.12+/3.14 compatibility issue where `pkg_resources` is no longer available

## Changes

| File | Change |
|------|--------|
| `ai_commit_msg/utils/utils.py` | Removed unused `import pkg_resources` |
| `ai_commit_msg/services/pip_service.py` | Replaced deprecated `pkg_resources` with `importlib.metadata` |

## Test Plan

- [x] Verify the package imports correctly on Python 3.14
- [x] Verify CLI runs: `git-ai-commit --version`

---

Closes: #82